### PR TITLE
Fix Kannada translation in header sign

### DIFF
--- a/src/lib/components/header-sign.svelte
+++ b/src/lib/components/header-sign.svelte
@@ -25,7 +25,7 @@
 					<div class="glass-overlay"></div>
 					<div class="display-content">
 						<div class="title-section">
-							<div class="kannada-text">ಬೆಂಗಳೂರು ಮೆಟ್ರೋವನ್ನು ಹೇಗೆ ಚಲಿಸುತ್ತದೆ</div>
+							<div class="kannada-text">ಬೆಂಗಳೂರು ಮೆಟ್ರೋವನ್ನು ಹೇಗೆ ಬಳಿಸುತ್ತದೆ</div>
 							<div class="main-title-row">
 								<div class="main-title">
 									How <FlickerText text="Bangalore" flickerIntensity="medium" /> Uses the <FlickerText


### PR DESCRIPTION
<img width="1366" height="743" alt="Screenshot_2025-10-02_15-44-16" src="https://github.com/user-attachments/assets/4b7784b5-78ae-4359-af80-d8971d2cb94c" />
Kannada translation fix